### PR TITLE
Fix assembly_shipment_serializer_spec to match changes made in model

### DIFF
--- a/spec/serializers/spree/wombat/assembly_shipment_serializer_spec.rb
+++ b/spec/serializers/spree/wombat/assembly_shipment_serializer_spec.rb
@@ -2,35 +2,36 @@ require "spec_helper"
 
 module Spree
   module Wombat
-    describe AssemblyShipmentSerializer do
+    if defined?(ShipmentSerializer)
+      describe AssemblyShipmentSerializer do
 
-      let(:order) { Order.create }
-      before { order.update_column :state, 'complete' }
+        let(:order) { Order.create }
+        before { order.update_column :state, 'complete' }
 
-      context "with bundle line item" do
+        context "with bundle line item" do
 
-        let(:bundle) { create(:variant) }
-        let!(:parts) { (1..2).map { create(:variant) } }
-        let!(:bundle_parts) { bundle.product.parts << parts }
-        let!(:line_item) { order.contents.add(bundle, 1) }
-        let!(:shipment) { order.create_proposed_shipments.first }
-        let(:serialized_shipment) { JSON.parse (AssemblyShipmentSerializer.new(shipment, root: false).to_json) }
+          let(:bundle) { create(:variant) }
+          let!(:parts) { (1..2).map { create(:variant) } }
+          let!(:bundle_parts) { bundle.product.parts << parts }
+          let!(:line_item) { order.contents.add(bundle, 1) }
+          let!(:shipment) { order.create_proposed_shipments.first }
+          let(:serialized_shipment) { JSON.parse (AssemblyShipmentSerializer.new(shipment, root: false).to_json) }
 
-        it "adds a bundled_items object" do
-          expect(serialized_shipment["items"].first["bundled_items"]).to_not be_nil
+          it "adds a bundled_items object" do
+            expect(serialized_shipment["items"].first["bundled_items"]).to_not be_nil
+          end
+        end
+
+        context "with regular line_item" do
+          let!(:line_item) { order.contents.add(create(:variant), 1) }
+          let!(:shipment) { order.create_proposed_shipments.first }
+          let(:serialized_shipment) { JSON.parse (AssemblyShipmentSerializer.new(shipment, root: false).to_json) }
+
+          it "will not add the bundled_items object" do
+            expect(serialized_shipment["items"].first["bundled_items"]).to be_nil
+          end
         end
       end
-
-      context "with regular line_item" do
-        let!(:line_item) { order.contents.add(create(:variant), 1) }
-        let!(:shipment) { order.create_proposed_shipments.first }
-        let(:serialized_shipment) { JSON.parse (AssemblyShipmentSerializer.new(shipment, root: false).to_json) }
-
-        it "will not add the bundled_items object" do
-          expect(serialized_shipment["items"].first["bundled_items"]).to be_nil
-        end
-      end
-
     end
   end
 end


### PR DESCRIPTION
Commit 5c6eb7cc99 changed the Spree::Wombat::AssemblyShipmentSerializer model such that now the model is created only if ShipmentSerializer is defined. This caused assembly_shipment_serializer_spec.rb to abort with a load error because the AssemblyShipmentSerializer model name was not defined. The revised spec makes the same is defined?(ShipmentSerializer) check as the model so the spec does not abort.